### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # api_specs
-The API Specs (in OpenAPI format, formerly Swagger) for the APIs available from [developer.nytimes.com](developer.nytimes.com)
+The API Specs (in OpenAPI format, formerly Swagger) for the APIs available from [developer.nytimes.com](http://developer.nytimes.com)
 
 Learn more about OpenAPI [here](https://openapis.org/)
 


### PR DESCRIPTION
Fix missing http prefix, causing the link to be a relative URL when rendered
