### PR TITLE
Removing trailing slashes from basePaths

### DIFF
--- a/event_listings/event_listings_v2.json
+++ b/event_listings/event_listings_v2.json
@@ -13,7 +13,7 @@
     "http",
     "https"
   ],
-  "basePath": "\/svc\/events\/v2\/",
+  "basePath": "\/svc\/events\/v2",
   "produces": [
     "application\/json"
   ],

--- a/movie_reviews/movie_reviews_v2.json
+++ b/movie_reviews/movie_reviews_v2.json
@@ -13,7 +13,7 @@
     "http",
     "https"
   ],
-  "basePath": "/svc/movies/v2/",
+  "basePath": "/svc/movies/v2",
   "produces": [
     "application/json"
   ],

--- a/times_tags/times_tags_v3.json
+++ b/times_tags/times_tags_v3.json
@@ -13,7 +13,7 @@
     "http",
     "https"
   ],
-  "basePath": "/svc/suggest/v1/",
+  "basePath": "/svc/suggest/v1",
   "produces": [
     "application/json"
   ],

--- a/top_stories/top_stories.json
+++ b/top_stories/top_stories.json
@@ -14,7 +14,7 @@
     "http",
     "https"
   ],
-  "basePath": "/svc/topstories/v1/",
+  "basePath": "/svc/topstories/v1",
   "produces": [
     "application/json"
   ],

--- a/top_stories/top_stories_v2.json
+++ b/top_stories/top_stories_v2.json
@@ -13,7 +13,7 @@
     "http",
     "https"
   ],
-  "basePath": "/svc/topstories/v2/",
+  "basePath": "/svc/topstories/v2",
   "produces": [
     "application/json"
   ],


### PR DESCRIPTION
Having a trailing slash in the basePath causes a double-slash when each path has a leading slash. Basepath shouldn't have a trailing slash. 
