### PR TITLE
Fixed parameters definitions

### DIFF
--- a/most_popular_api/most_popular_api_v2.json
+++ b/most_popular_api/most_popular_api_v2.json
@@ -21,16 +21,10 @@
         "/mostshared/{section}/{time-period}.json": {
             "parameters": [
                 {
-                    "name": "section",
-                    "in": "path",
-                    "required": true,
-                    "type": "string"
+                  "$ref": "#/parameters/Section"
                 },
                 {
-                    "name": "time-period",
-                    "in": "path",
-                    "required": true,
-                    "type": "string"
+                  "$ref": "#/parameters/TimePeriod"
                 }
             ],
             "get": {
@@ -166,16 +160,10 @@
         "/mostemailed/{section}/{time-period}.json": {
             "parameters": [
                 {
-                    "name": "section",
-                    "in": "path",
-                    "required": true,
-                    "type": "string"
+                  "$ref": "#/parameters/Section"
                 },
                 {
-                    "name": "time-period",
-                    "in": "path",
-                    "required": true,
-                    "type": "string"
+                  "$ref": "#/parameters/TimePeriod"
                 }
             ],
             "get": {
@@ -278,7 +266,14 @@
             }
         },
         "/mostviewed/{section}/{time-period}.json": {
-            "parameters": [],
+            "parameters": [
+                {
+                  "$ref": "#/parameters/Section"
+                },
+                {
+                  "$ref": "#/parameters/TimePeriod"
+                }
+            ],
             "get": {
                 "summary": "Most Viewed by Section & Time Period",
                 "description": "",
@@ -395,32 +390,6 @@
                 "string"
             ],
             "items": {}
-        },
-        "TimePeriod": {
-            "in": "path",
-            "description": "Number of days `1 | 7 | 30 ` corresponds to a day, a week, or a month of content.",
-            "type": "string",
-            "enum": [
-                "1",
-                "7",
-                "30"
-            ]
-        },
-        "SharedTypes": {
-            "in": "query",
-            "description": "Limits the results by the method used to share the items only works on mostshared requests.",
-            "type": "string",
-            "enum": [
-                "digg",
-                "email",
-                "facebook",
-                "mixx",
-                "myspace",
-                "permalink",
-                "timespeople",
-                "twitter",
-                "yahoobuzz"
-            ]
         },
         "Article": {
             "type": "object",
@@ -552,8 +521,39 @@
                     }
                 }
             }
+        }
+    },
+    "parameters": {
+        "TimePeriod": {
+            "name": "time-period",
+            "in": "path",
+            "description": "Number of days `1 | 7 | 30 ` corresponds to a day, a week, or a month of content.",
+            "type": "string",
+            "enum": [
+                "1",
+                "7",
+                "30"
+            ]
+        },
+        "SharedTypes": {
+            "name": "shared-types",
+            "in": "query",
+            "description": "Limits the results by the method used to share the items only works on mostshared requests.",
+            "type": "string",
+            "enum": [
+                "digg",
+                "email",
+                "facebook",
+                "mixx",
+                "myspace",
+                "permalink",
+                "timespeople",
+                "twitter",
+                "yahoobuzz"
+            ]
         },
         "Section": {
+            "name": "section",
             "in": "path",
             "description": "Limits the results by one or more sections. You can use\n`all-sections` or one or more section names seperated by semicolons. See `viewed/sections.json` call to get a list of sections. \n",
             "type": "string",
@@ -597,6 +597,7 @@
             ]
         },
         "OffSet": {
+            "name": "offset",
             "in": "query",
             "description": "Positive integer in a multiple of 20",
             "type": "integer",

--- a/most_popular_api/most_popular_api_v2.json
+++ b/most_popular_api/most_popular_api_v2.json
@@ -171,14 +171,7 @@
                     "application/json",
                     "application/xml"
                 ],
-                "parameters": [
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "",
-                        "type": "string"
-                    }
-                ],
+                "parameters": [],
                 "responses": {
                     "200": {
                         "description": "An array of Articles",
@@ -273,14 +266,7 @@
                 "produces": [
                     "application/json"
                 ],
-                "parameters": [
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "",
-                        "type": "string"
-                    }
-                ],
+                "parameters": [],
                 "responses": {
                     "200": {
                         "description": "An array of Articles",

--- a/most_popular_api/most_popular_api_v2.json
+++ b/most_popular_api/most_popular_api_v2.json
@@ -37,13 +37,7 @@
                 "produces": [
                     "application/json"
                 ],
-                "parameters": [
-                    {
-                        "name": "api-key",
-                        "in": "query",
-                        "type": "string"
-                    }
-                ],
+                "parameters": [],
                 "responses": {
                     "200": {
                         "description": "An array of Articles",
@@ -178,11 +172,6 @@
                     "application/xml"
                 ],
                 "parameters": [
-                    {
-                        "name": "api-key",
-                        "in": "query",
-                        "type": "string"
-                    },
                     {
                         "name": "Accept",
                         "in": "header",


### PR DESCRIPTION
parameters should be defined in `parameters` section, not in `definitions`:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parametersDefinitionsObject
This leads to validation errors:

```
- code: OBJECT_ADDITIONAL_PROPERTIES
  description: A deterministic version of a JSON Schema object.
  message: 'Additional properties not allowed: in'
  params:
    - - in
  path:
    - definitions
    - OffSet
  schemaId: 'http://swagger.io/v2/schema.json#'
- code: OBJECT_ADDITIONAL_PROPERTIES
  description: A deterministic version of a JSON Schema object.
  message: 'Additional properties not allowed: in'
  params:
    - - in
  path:
    - definitions
    - Section
  schemaId: 'http://swagger.io/v2/schema.json#'
- code: OBJECT_ADDITIONAL_PROPERTIES
  description: A deterministic version of a JSON Schema object.
  message: 'Additional properties not allowed: in'
  params:
    - - in
  path:
    - definitions
    - SharedTypes
  schemaId: 'http://swagger.io/v2/schema.json#'
- code: OBJECT_ADDITIONAL_PROPERTIES
  description: A deterministic version of a JSON Schema object.
  message: 'Additional properties not allowed: in'
  params:
    - - in
  path:
    - definitions
    - TimePeriod
  schemaId: 'http://swagger.io/v2/schema.json#'
```
