### PR TITLE
Bugfix/update top storiesv2 spec

### DIFF
--- a/top_stories/top_stories_v2.json
+++ b/top_stories/top_stories_v2.json
@@ -161,7 +161,10 @@
           }
         },
         "org_facet": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "per_facet": {
           "type": "array",

--- a/top_stories/top_stories_v2.md
+++ b/top_stories/top_stories_v2.md
@@ -64,9 +64,15 @@ Here is a portion of a sample JSON response:
                 "Democratic Party",
                 "Republican Party"
             ],
-            per_facet: "",
-            geo_facet: "",
-            multimedia: 
+            "per_facet":[  
+                "Scott, Keith Lamont (1973-2016)",
+                "McCrory, Pat"
+            ],
+            "geo_facet":[  
+                "North Carolina",
+                "Charlotte (NC)"
+            ],
+            multimedia:
             [
                 {
                     url: "http://static01.nyt.com/images/2014/12/03/business/Economy/Economy-thumbStandard.jpg",
@@ -83,7 +89,7 @@ Here is a portion of a sample JSON response:
         },
         ...
     ]
-} 
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Supported Multimedia Options


### PR DESCRIPTION
## Summary

Fixed some issue that I found during development.
## Changelog
- [FIXED] API specification for `Article` schema. Based on current response, `org_facet` is array of strings.
- [UPDATE] Fixed example JSON response for top stories v2. Both `per_facet` and `geo_facet` is now array of strings.
### Notes

After this is approved and merged, you might have to updated the source that is pointed from https://developer.nytimes.com/top_stories_v2.json - because currently it points to https://developer.nytimes.com/top_stories_v2.json/swagger.json
